### PR TITLE
Upgrade chat widget with fullscreen, history, and conversations

### DIFF
--- a/app/api/chat/tools.ts
+++ b/app/api/chat/tools.ts
@@ -455,15 +455,16 @@ async function handleSearchGoogleMaps(toolParams: Record<string, unknown>, toolS
     sendStep("search_google");
     try {
       const searchResult = await searchGoogleApify(apifyToken, [`${query} businesses companies`, `${query} directory list`], tavilyKey);
-      const urlRegex = /\(([^)]+)\)/g;
-      const titleRegex = /\*\*([^*]+)\*\*/g;
-      let match;
-      while ((match = titleRegex.exec(searchResult)) !== null) {
-        const title = match[1];
-        const urlMatch = urlRegex.exec(searchResult);
-        const url = urlMatch ? urlMatch[1] : "";
-        if (title && !title.includes("Search:")) {
-          results.push({ name: title, website: url, phone: "", address: "", category: "" });
+      // Parse each line: "- **Title** (url): description"
+      const lineRegex = /^- \*\*([^*]+)\*\*\s*\(([^)]*)\)/;
+      for (const line of searchResult.split("\n")) {
+        const match = lineRegex.exec(line);
+        if (match) {
+          const title = match[1];
+          const url = match[2];
+          if (title && !title.includes("Search:")) {
+            results.push({ name: title, website: url, phone: "", address: "", category: "" });
+          }
         }
       }
     } catch (err) {
@@ -490,8 +491,9 @@ async function handleSearchGoogleMaps(toolParams: Record<string, unknown>, toolS
       return `**Google Maps search: "${query}"**\n\nNo businesses found. Try broadening your search terms or checking the location.`;
     }
 
+    const esc = (s: string) => s.replace(/\|/g, "\\|");
     const rows = results.map((r) =>
-      `| ${r.name || "—"} | ${r.website || "—"} | ${r.phone || "—"} | ${r.address || "—"} | ${r.category || "—"} |`
+      `| ${esc(r.name) || "—"} | ${esc(r.website) || "—"} | ${esc(r.phone) || "—"} | ${esc(r.address) || "—"} | ${esc(r.category) || "—"} |`
     ).join("\n");
 
     let result = `**${toolSummary || "Google Maps Search"}**\n\nFound **${results.length}** businesses:\n\n| Company | Website | Phone | Address | Category |\n|---------|---------|-------|---------|----------|\n${rows}`;

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -234,7 +234,7 @@ export default function ChatWidget() {
                 </svg>
               </button>
               {/* Fullscreen toggle */}
-              <button onClick={() => setFullscreen((f) => !f)} className="text-white/70 hover:text-white cursor-pointer p-1" title={fullscreen ? tc.minimize || "Minimize" : tc.fullscreen || "Fullscreen"}>
+              <button onClick={() => setFullscreen((f) => !f)} className="text-white/70 hover:text-white cursor-pointer p-1" title={fullscreen ? "Minimize" : "Fullscreen"}>
                 {fullscreen ? (
                   <svg className="w-4.5 h-4.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 9L4 4m0 0v4m0-4h4m6 6l5 5m0 0v-4m0 4h-4M9 15l-5 5m0 0v-4m0 4h4m6-6l5-5m0 0v4m0-4h-4" />

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -207,7 +207,7 @@ export default function ChatWidget() {
             <div className="flex items-center gap-2">
               <span className="font-semibold text-sm">{tc.chat}</span>
               {activeConvId !== null && (
-                <span className="text-white/60 text-xs truncate max-w-30">
+                <span className="text-white/60 text-xs truncate max-w-[120px]">
                   — {conversations.find((c) => c.id === activeConvId)?.title || ""}
                 </span>
               )}

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -672,6 +672,7 @@ const en = {
     chatNewConv: "New Chat",
     chatNew: "New",
     chatGeneral: "General",
+    chatNoConv: "No conversations yet",
     chatPageTitle: "AI Chat",
     chatToolHistory: "Tool executions",
     // Billing

--- a/lib/i18n/fr.ts
+++ b/lib/i18n/fr.ts
@@ -658,6 +658,7 @@ const fr: typeof en = {
     chatNewConv: "Nouvelle discussion",
     chatNew: "Nouveau",
     chatGeneral: "Général",
+    chatNoConv: "Aucune conversation",
     chatPageTitle: "Chat IA",
     chatToolHistory: "Exécutions d'outils",
     activeSubscriptions: "Abonnements actifs",

--- a/lib/i18n/zh-TW.ts
+++ b/lib/i18n/zh-TW.ts
@@ -658,6 +658,7 @@ const zhTW: typeof en = {
     chatNewConv: "新對話",
     chatNew: "新建",
     chatGeneral: "通用對話",
+    chatNoConv: "暫無對話記錄",
     chatPageTitle: "AI 對話",
     chatToolHistory: "工具執行記錄",
     activeSubscriptions: "目前訂閱",

--- a/lib/i18n/zh.ts
+++ b/lib/i18n/zh.ts
@@ -658,6 +658,7 @@ const zh: typeof en = {
     chatNewConv: "新对话",
     chatNew: "新建",
     chatGeneral: "通用对话",
+    chatNoConv: "暂无对话记录",
     chatPageTitle: "AI 对话",
     chatToolHistory: "工具执行记录",
     activeSubscriptions: "当前订阅",


### PR DESCRIPTION
## Summary
- Add fullscreen expand/minimize toggle to chat widget
- Add conversation history sidebar with list of past conversations
- Add new conversation button to start fresh chats
- Support switching between conversations and deleting them
- Auto-name conversations based on first message
- Track conversation_id when sending messages
- Add i18n keys for new chat widget features (en, zh, zh-TW, fr)

Cherry-picked from `yeoso` branch (5d0bd30 + 38a2456).

## Test plan
- [ ] Open chat widget, verify fullscreen toggle works
- [ ] Click new conversation button, verify empty chat starts
- [ ] Send a message, verify it auto-names the conversation
- [ ] Open history sidebar, verify conversations are listed
- [ ] Switch between conversations, verify messages load correctly
- [ ] Delete a conversation from the sidebar
- [ ] Verify all i18n strings render in each locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)