### PR TITLE
Improve crawl error messages to be user-friendly

### DIFF
--- a/app/api/chat/tools.ts
+++ b/app/api/chat/tools.ts
@@ -201,10 +201,16 @@ async function crawlWithFirecrawl(apiKey: string, url: string): Promise<string> 
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`Firecrawl error ${res.status}: ${text.substring(0, 200)}`);
+    if (res.status === 401 || res.status === 403) {
+      throw new Error("Firecrawl API key is invalid or expired. Please update it in Settings > API Keys.");
+    }
+    if (res.status === 429) {
+      throw new Error("Firecrawl rate limit reached. Please wait a moment and try again.");
+    }
+    throw new Error(`Firecrawl service error (${res.status}). Please try again later.`);
   }
   const data = (await res.json()) as { success?: boolean; data?: { markdown?: string; metadata?: { title?: string; description?: string } } };
-  if (!data.success || !data.data?.markdown) throw new Error("Firecrawl returned no content");
+  if (!data.success || !data.data?.markdown) throw new Error("The page returned no readable content. It may require JavaScript or login to access.");
   const md = data.data.markdown;
   const title = data.data.metadata?.title || "";
   const desc = data.data.metadata?.description || "";
@@ -224,7 +230,7 @@ async function handleCrawlWebsite(toolParams: Record<string, unknown>, apifyToke
     } catch (err) {
       // Fall through to Apify
       if (!apifyToken) {
-        return `Website crawl failed: ${err instanceof Error ? err.message : "Unknown error"}`;
+        return `Unable to crawl **${url}**: ${err instanceof Error ? err.message : "Something went wrong. Please try again."}`;
       }
     }
   }
@@ -235,7 +241,7 @@ async function handleCrawlWebsite(toolParams: Record<string, unknown>, apifyToke
       const content = await crawlWebsiteApify(apifyToken, url);
       return `**Website content from ${url}** *(via Apify)*\n\n${content.substring(0, 3000)}`;
     } catch (err) {
-      return `Website crawl failed: ${err instanceof Error ? err.message : "Unknown error"}. The site may be blocking crawlers.`;
+      return `Unable to crawl **${url}**: ${err instanceof Error ? err.message : "Something went wrong."} The site may also be blocking automated access.`;
     }
   }
 
@@ -247,8 +253,8 @@ async function handleCrawlWebsite(toolParams: Record<string, unknown>, apifyToke
     const titleMatch = html.match(/<title[^>]*>(.*?)<\/title>/i);
     const body = html.replace(/<script[\s\S]*?<\/script>/gi, "").replace(/<style[\s\S]*?<\/style>/gi, "").replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
     return `**Website content from ${url}** *(direct fetch)*\n\n${titleMatch?.[1] ? `**${titleMatch[1].trim()}**\n\n` : ""}${body.substring(0, 3000)}`;
-  } catch (err) {
-    return `Website crawl failed: ${err instanceof Error ? err.message : "Unknown error"}. Please add a Firecrawl API key (free 500 pages/mo) or Apify token in Settings > API Keys.`;
+  } catch {
+    return `Unable to crawl **${url}**. The site may be blocking automated access. To improve success rate, add a Firecrawl API key (free 500 pages/mo) or Apify token in Settings > API Keys.`;
   }
 }
 

--- a/lib/leads.ts
+++ b/lib/leads.ts
@@ -498,18 +498,24 @@ async function runApifyActor<T = Record<string, unknown>>(
   );
   if (!startRes.ok) {
     const text = await startRes.text().catch(() => "");
-    throw new Error(`Apify ${actorId} start error ${startRes.status}: ${text.substring(0, 200)}`);
+    if (startRes.status === 403 && text.includes("usage hard limit")) {
+      throw new Error("Apify monthly usage limit exceeded. Please upgrade your Apify plan or wait for the quota to reset.");
+    }
+    if (startRes.status === 401) {
+      throw new Error("Apify API token is invalid or expired. Please update it in Settings > API Keys.");
+    }
+    throw new Error(`Apify service error (${startRes.status}). Please try again later.`);
   }
   const runData = (await startRes.json()) as {
     data?: { id?: string; status?: string; defaultDatasetId?: string; statusMessage?: string };
   };
   const run = runData.data;
-  if (!run?.id) throw new Error(`Apify ${actorId}: no run ID returned`);
+  if (!run?.id) throw new Error("Apify failed to start the crawl task. Please try again.");
 
   let datasetId = run.defaultDatasetId;
 
   if (run.status === "FAILED" || run.status === "ABORTED") {
-    throw new Error(`Apify ${actorId} run ${run.status}: ${String(run.statusMessage || "unknown").substring(0, 200)}`);
+    throw new Error(`Crawl task failed (${run.status.toLowerCase()}). ${run.statusMessage ? String(run.statusMessage).substring(0, 150) : "Please try again."}`);
   }
 
   if (run.status !== "SUCCEEDED") {
@@ -518,14 +524,14 @@ async function runApifyActor<T = Record<string, unknown>>(
     return [];
   }
 
-  if (!datasetId) throw new Error(`Apify ${actorId}: no dataset ID`);
+  if (!datasetId) throw new Error("Crawl completed but no results were returned. Please try again.");
 
   const limit = opts.itemsLimit ?? 200;
   const itemsRes = await fetch(
     `https://api.apify.com/v2/datasets/${datasetId}/items?token=${apiToken}&limit=${limit}`,
   );
   if (!itemsRes.ok) {
-    throw new Error(`Apify ${actorId} dataset error ${itemsRes.status}`);
+    throw new Error(`Failed to retrieve crawl results (${itemsRes.status}). Please try again.`);
   }
   return (await itemsRes.json()) as T[];
 }


### PR DESCRIPTION
## Summary
- Replace raw Apify/Firecrawl error dumps with clear, actionable messages
- Handle specific error codes: 403 (usage limit), 401 (invalid token), 429 (rate limit)
- Guide users to Settings > API Keys when credentials are missing or expired
- Improve "no content" errors to suggest JS-heavy or login-protected pages

Cherry-picked from `yeoso` branch (04682ed).

## Test plan
- [ ] Trigger Apify 403 error, verify friendly "usage limit exceeded" message
- [ ] Trigger Firecrawl 401, verify "API key invalid" message
- [ ] Crawl a site with no Apify/Firecrawl keys, verify Settings guidance shown
- [ ] Verify successful crawls still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)