### PR TITLE
Integrate xPilot AI gateway for email template generation & imagery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ docs/sales/first-outreach-log.json
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Claude Code local config
+.claude/
+
+# local backups
+*.before-xpilot

--- a/app/api/email-templates/route.ts
+++ b/app/api/email-templates/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth0 } from "@/lib/auth0";
 import { getDb } from "@/lib/db";
 import { chatWithAI, type ByokKeys } from "@/lib/ai";
+import { generateEmailImage } from "@/lib/xpilot-image";
 import { decrypt } from "@/lib/crypto";
 
 export const dynamic = "force-dynamic";
@@ -331,6 +332,74 @@ Reply with ONLY a JSON object (no markdown): {"template_id": <number>, "reason":
       } catch {
         return NextResponse.json({ success: false, error: "AI returned invalid format", raw: aiResp.content });
       }
+    }
+
+    // AI Image: generate a hero image for an email via xPilot.
+    // Pass `prompt` directly, or `id` to auto-write a prompt from the template.
+    // With `attach: true`, the image is embedded at the top of the template body.
+    if (action === "ai_image") {
+      const { id, prompt, model, aspect_ratio, attach } = body;
+
+      // Resolve the image prompt — explicit, or AI-written from template content.
+      let imagePrompt = (prompt as string)?.trim() || "";
+      let tpl: Record<string, unknown> | null = null;
+
+      if (id) {
+        const rows = await sql`SELECT * FROM email_templates WHERE id = ${id} AND user_id = ${userId}`;
+        if (rows.length === 0) return NextResponse.json({ error: "Template not found" }, { status: 404 });
+        tpl = rows[0];
+      }
+
+      if (!imagePrompt) {
+        if (!tpl) return NextResponse.json({ error: "prompt or id is required" }, { status: 400 });
+
+        // Resolve BYOK for the prompt-writing step
+        const byok: ByokKeys = {};
+        try {
+          const byokRows = await sql`
+            SELECT service, api_key FROM user_api_keys
+            WHERE user_id = ${userId} AND service IN ('openai', 'anthropic', 'google', 'alibaba', 'cerebras')
+          `;
+          for (const row of byokRows) {
+            try { byok[row.service as keyof ByokKeys] = decrypt(row.api_key as string); } catch { /* skip */ }
+          }
+        } catch { /* continue */ }
+
+        const bodyText = (tpl.body_html as string).replace(/<[^>]+>/g, " ").slice(0, 600);
+        const promptResp = await chatWithAI([{
+          role: "user",
+          content: `Write a concise image-generation prompt for a marketing email hero image. The email:
+Subject: ${tpl.subject}
+Body: ${bodyText}
+
+Reply with ONLY the image prompt (one sentence, vivid, no people's faces, no text in the image, professional marketing style).`,
+        }], 120, byok);
+        imagePrompt = promptResp.content.trim().replace(/^["']|["']$/g, "");
+      }
+
+      // Generate the image via xPilot
+      let image;
+      try {
+        image = await generateEmailImage({
+          prompt: imagePrompt,
+          model: model || undefined,
+          aspectRatio: aspect_ratio || "16:9",
+        });
+      } catch (e) {
+        return NextResponse.json({ success: false, error: e instanceof Error ? e.message : "Image generation failed" }, { status: 502 });
+      }
+
+      // Optionally embed the image at the top of the template body
+      if (attach && tpl) {
+        const imgTag = `<img src="${image.url}" alt="" style="width:100%;max-width:600px;height:auto;display:block;margin:0 auto 16px" />`;
+        await sql`
+          UPDATE email_templates
+          SET body_html = ${imgTag + "\n" + (tpl.body_html as string)}, updated_at = NOW()
+          WHERE id = ${id} AND user_id = ${userId}
+        `;
+      }
+
+      return NextResponse.json({ success: true, url: image.url, prompt: imagePrompt, model: image.model, attached: !!(attach && tpl) });
     }
 
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -3,6 +3,8 @@ const NVIDIA_API_KEY = process.env.NVIDIA_API_KEY;
 const GOOGLE_AI_API = process.env.GOOGLE_AI_API;
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 const ALIBABA_AI_BASE_URL = process.env.ALIBABA_AI_BASE_URL || "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+const XPILOT_API_KEY = process.env.XPILOT_API_KEY;
+const XPILOT_BASE_URL = process.env.XPILOT_BASE_URL || "https://xpilot.jytech.us/api/v1";
 
 interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -57,6 +59,9 @@ export const AVAILABLE_MODELS: ModelInfo[] = [
   { id: "cerebras/qwen-3-235b", name: "Alibaba Qwen 3 235B", provider: "cerebras", costPer1MInput: 0, costPer1MOutput: 0, requiresByok: "cerebras" },
   { id: "cerebras/qwen-3-coder-480b", name: "Alibaba Qwen 3 Coder 480B", provider: "cerebras", costPer1MInput: 0, costPer1MOutput: 0, requiresByok: "cerebras" },
   { id: "cerebras/llama3.1-8b", name: "Meta Llama 3.1 8B", provider: "cerebras", costPer1MInput: 0, costPer1MOutput: 0, requiresByok: "cerebras" },
+  // xPilot gateway (JYTech — platform key, billed per call via xPilot credits)
+  { id: "xpilot/gpt-4o", name: "GPT-4o (xPilot)", provider: "xpilot", costPer1MInput: 250, costPer1MOutput: 1000 },
+  { id: "xpilot/claude-sonnet", name: "Claude Sonnet (xPilot)", provider: "xpilot", costPer1MInput: 300, costPer1MOutput: 1500 },
 ];
 
 export const DEFAULT_MODEL = "cerebras/gpt-oss-120b";
@@ -214,6 +219,43 @@ async function callOpenRouter(model: string, messages: ChatMessage[], maxTokens:
   };
 }
 
+// --- xPilot (JYTech gateway — flat prompt+system, NOT OpenAI messages) ---
+async function callXPilot(apiKey: string, model: string, messages: ChatMessage[], maxTokens: number): Promise<AIResponse> {
+  // xPilot's /text/generate takes a single `prompt` + optional `system`, so flatten the message list.
+  const sys = messages.filter((m) => m.role === "system").map((m) => m.content);
+  const rest = messages.filter((m) => m.role !== "system");
+  const system = sys.length ? sys.join("\n\n") : undefined;
+  const prompt = rest.length === 1
+    ? rest[0].content
+    : rest.map((m) => `${m.role.toUpperCase()}: ${m.content}`).join("\n\n");
+
+  const res = await fetch(`${XPILOT_BASE_URL}/text/generate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model, prompt, system, max_tokens: maxTokens }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`xpilot error ${res.status}: ${err}`);
+  }
+
+  const data = await res.json();
+  return {
+    content: data.content || "",
+    provider: "xpilot",
+    model: data.model || model,
+    usage: data.usage ? {
+      prompt_tokens: data.usage.prompt_tokens || 0,
+      completion_tokens: data.usage.completion_tokens || 0,
+      total_tokens: data.usage.total_tokens || 0,
+    } : undefined,
+  };
+}
+
 // ── Benchmark-based auto model cache ──
 // In-memory cache of the best model from benchmarks (refreshed on cold start or every 1h)
 let _cachedBestModel: { modelId: string; provider: string; fetchedAt: number } | null = null;
@@ -260,6 +302,8 @@ const MODEL_API_MAP: Record<string, string> = {
   "cerebras/qwen-3-235b": "qwen-3-235b-a22b-instruct-2507",
   "cerebras/qwen-3-coder-480b": "qwen-3-coder-480b",
   "cerebras/llama3.1-8b": "llama3.1-8b",
+  "xpilot/gpt-4o": "openai/gpt-4o",
+  "xpilot/claude-sonnet": "anthropic/claude-sonnet-4",
 };
 
 export async function chatWithAI(messages: ChatMessage[], maxTokens = 500, byok?: ByokKeys, selectedModel?: string): Promise<AIResponse> {
@@ -289,6 +333,9 @@ export async function chatWithAI(messages: ChatMessage[], maxTokens = 500, byok?
       }
       if (provider === "alibaba" && byok?.alibaba) {
         return await callOpenAICompatible(`${ALIBABA_AI_BASE_URL}/chat/completions`, byok.alibaba, apiModel, provider, messages, maxTokens);
+      }
+      if (provider === "xpilot" && XPILOT_API_KEY) {
+        return await callXPilot(XPILOT_API_KEY, apiModel, messages, maxTokens);
       }
       // If the selected model can't be used, fall through to auto
     }
@@ -346,6 +393,9 @@ export async function chatWithAI(messages: ChatMessage[], maxTokens = 500, byok?
     providers.push({ name: "Cerebras qwen-3-235b", call: () => callOpenAICompatible("https://api.cerebras.ai/v1/chat/completions", CEREBRAS_API_KEY, "qwen-3-235b-a22b-instruct-2507", "cerebras", messages, maxTokens) });
   }
   if (GOOGLE_AI_API) providers.push({ name: "Google", call: () => callGoogle(GOOGLE_AI_API, "gemini-2.0-flash", messages, maxTokens) });
+
+  // 3. xPilot paid gateway — after free platform keys, before BYOK
+  if (XPILOT_API_KEY) providers.push({ name: "xPilot", call: () => callXPilot(XPILOT_API_KEY, "openai/gpt-4o", messages, maxTokens) });
 
   // BYOK keys as fallback
   if (byok?.openai) providers.push({ name: "BYOK OpenAI", call: () => callOpenAICompatible("https://api.openai.com/v1/chat/completions", byok.openai!, "gpt-4o-mini", "openai", messages, maxTokens) });

--- a/lib/xpilot-image.ts
+++ b/lib/xpilot-image.ts
@@ -1,0 +1,101 @@
+/**
+ * xPilot image generation helper.
+ * Submits a text-to-image task to the xPilot gateway and polls until it
+ * completes, returning the final image URL(s). Used for email hero images.
+ *
+ * xPilot image API:
+ *   POST /image/generate  → { task_id, status, outputs?, poll_url? }
+ *   GET  <poll_url>       → { task_id, status, outputs, error }
+ */
+
+const XPILOT_API_KEY = process.env.XPILOT_API_KEY;
+const XPILOT_BASE_URL = process.env.XPILOT_BASE_URL || "https://xpilot.jytech.us/api/v1";
+const XPILOT_ORIGIN = new URL(XPILOT_BASE_URL).origin;
+
+// Default text-to-image model — fast and good for marketing imagery.
+export const DEFAULT_EMAIL_IMAGE_MODEL = "bytedance/seedream-v4";
+
+export interface EmailImageResult {
+  url: string;
+  model: string;
+  costCents: number;
+}
+
+interface GenerateOpts {
+  prompt: string;
+  model?: string;
+  aspectRatio?: string; // e.g. "16:9", "1:1"
+  /** Max time to wait for an async task before giving up (ms). */
+  timeoutMs?: number;
+}
+
+/**
+ * Generate one image via xPilot. Resolves once the task completes.
+ * Throws on auth failure, API error, task failure, or timeout.
+ */
+export async function generateEmailImage(opts: GenerateOpts): Promise<EmailImageResult> {
+  if (!XPILOT_API_KEY) throw new Error("XPILOT_API_KEY not configured");
+
+  const model = opts.model || DEFAULT_EMAIL_IMAGE_MODEL;
+  const timeoutMs = opts.timeoutMs ?? 50_000;
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${XPILOT_API_KEY}`,
+  };
+
+  // 1. Submit the task
+  const submitRes = await fetch(`${XPILOT_BASE_URL}/image/generate`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      prompt: opts.prompt,
+      aspect_ratio: opts.aspectRatio || "16:9",
+      mode: "t2i",
+    }),
+  });
+  if (!submitRes.ok) {
+    const err = await submitRes.text();
+    throw new Error(`xpilot image submit ${submitRes.status}: ${err.slice(0, 200)}`);
+  }
+  const submit = await submitRes.json() as {
+    task_id: string;
+    status: string;
+    outputs?: string[];
+    poll_url?: string;
+    cost_cents?: number;
+  };
+  const costCents = submit.cost_cents ?? 0;
+
+  // 2a. Sync models return the result immediately
+  if (submit.status === "completed" && submit.outputs?.length) {
+    return { url: submit.outputs[0], model, costCents };
+  }
+
+  // 2b. Async — poll until done or timeout
+  if (!submit.poll_url) {
+    throw new Error(`xpilot image: no outputs and no poll_url (status: ${submit.status})`);
+  }
+  const pollUrl = submit.poll_url.startsWith("http")
+    ? submit.poll_url
+    : `${XPILOT_ORIGIN}${submit.poll_url}`;
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 3000));
+    const pollRes = await fetch(pollUrl, { headers });
+    if (!pollRes.ok) continue; // transient — keep polling
+    const poll = await pollRes.json() as {
+      status: string;
+      outputs?: string[];
+      error?: string;
+    };
+    if (poll.status === "completed" && poll.outputs?.length) {
+      return { url: poll.outputs[0], model, costCents };
+    }
+    if (poll.status === "failed" || poll.error) {
+      throw new Error(`xpilot image failed: ${poll.error || "unknown error"}`);
+    }
+  }
+  throw new Error(`xpilot image timed out after ${timeoutMs}ms`);
+}


### PR DESCRIPTION
- lib/ai.ts: add callXPilot(), insert xPilot into the auto fallback chain after free platform keys and before BYOK; register xpilot/gpt-4o and xpilot/claude-sonnet models
- lib/xpilot-image.ts: new module — submit + poll xPilot image generation
- email-templates: add ai_image generation— generates a hero image (explicit prompt or AI-written from template), optionally embeds it in body_html