### PR TITLE
chore(google-ads): wire cron schedule + lift runtime schema into sche…

### DIFF
--- a/.github/workflows/cron-maintenance.yml
+++ b/.github/workflows/cron-maintenance.yml
@@ -11,6 +11,8 @@ on:
     - cron: "0 4 * * *"
     - cron: "30 3 * * *"
     - cron: "30 4 * * *"
+    - cron: "40 * * * *"      # hourly :40  - google-ads-sync
+    - cron: "45 3 * * *"      # daily 03:45 - google-ads-reconcile
   workflow_dispatch:
     inputs:
       task:
@@ -27,6 +29,8 @@ on:
           - post-scheduler
           - enrich-contacts
           - sync-billing
+          - google-ads-sync
+          - google-ads-reconcile
 
 jobs:
   cron:
@@ -131,3 +135,23 @@ jobs:
           curl --fail --show-error --silent \
             -H "Authorization: Bearer ${CRON_SECRET}" \
             "${AUTOCLAW_BASE_URL}/api/cron/enrich-contacts"
+
+      - name: Run google-ads-sync
+        if: (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'google-ads-sync') || (github.event_name == 'schedule' && github.event.schedule == '40 * * * *')
+        env:
+          AUTOCLAW_BASE_URL: ${{ vars.AUTOCLAW_BASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          curl --fail --show-error --silent \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            "${AUTOCLAW_BASE_URL}/api/cron/google-ads-sync"
+
+      - name: Run google-ads-reconcile
+        if: (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'google-ads-reconcile') || (github.event_name == 'schedule' && github.event.schedule == '45 3 * * *')
+        env:
+          AUTOCLAW_BASE_URL: ${{ vars.AUTOCLAW_BASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          curl --fail --show-error --silent \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            "${AUTOCLAW_BASE_URL}/api/cron/google-ads-reconcile"

--- a/app/api/credits/route.ts
+++ b/app/api/credits/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth0 } from "@/lib/auth0";
 import { getDb } from "@/lib/db";
-import { ensureAdCreditsTables, getCredits, getRecentTransactions, resolveOrgId } from "@/lib/credits";
+import { getCredits, getRecentTransactions, resolveOrgId } from "@/lib/credits";
 import { checkRateLimit } from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
@@ -21,7 +21,6 @@ export async function GET(req: NextRequest) {
   }
 
   const sql = getDb();
-  await ensureAdCreditsTables(sql);
 
   const users = await sql`SELECT id FROM users WHERE email = ${session.user.email as string}`;
   if (users.length === 0) {

--- a/app/api/credits/verify/route.ts
+++ b/app/api/credits/verify/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import Stripe from "stripe";
 import { auth0 } from "@/lib/auth0";
 import { getDb } from "@/lib/db";
-import { ensureAdCreditsTables, addTopup } from "@/lib/credits";
+import { addTopup } from "@/lib/credits";
 
 export const dynamic = "force-dynamic";
 
@@ -48,7 +48,6 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  await ensureAdCreditsTables(sql);
   const amountCents = checkout.amount_total || 0;
   const credits = await addTopup(sql, orgId, amountCents, sessionId);
 

--- a/app/api/google-ads/campaigns/route.ts
+++ b/app/api/google-ads/campaigns/route.ts
@@ -5,7 +5,6 @@ import { logAudit } from "@/lib/audit";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { createCampaign } from "@/lib/google-ads";
 import {
-  ensureAdCreditsTables,
   reserveForCampaign,
   attachReserveReference,
   applyPlatformMarkup,
@@ -20,53 +19,9 @@ function getIp(req: NextRequest): string {
   return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
 }
 
-async function ensureAdsTables() {
-  const sql = getDb();
-  await sql`
-    CREATE TABLE IF NOT EXISTS ad_accounts (
-      id SERIAL PRIMARY KEY,
-      org_id INTEGER REFERENCES organizations(id) ON DELETE CASCADE,
-      platform VARCHAR(20) NOT NULL,
-      account_id VARCHAR(100) NOT NULL,
-      account_name VARCHAR(255),
-      credentials JSONB,
-      is_active BOOLEAN DEFAULT true,
-      created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
-      created_at TIMESTAMP DEFAULT NOW(),
-      UNIQUE(org_id, platform, account_id)
-    )
-  `;
-  await sql`
-    CREATE TABLE IF NOT EXISTS campaigns (
-      id SERIAL PRIMARY KEY,
-      org_id INTEGER REFERENCES organizations(id) ON DELETE CASCADE,
-      ad_account_id INTEGER REFERENCES ad_accounts(id) ON DELETE SET NULL,
-      platform VARCHAR(20) NOT NULL,
-      platform_campaign_id VARCHAR(255),
-      campaign_name VARCHAR(255) NOT NULL,
-      channel VARCHAR(50),
-      daily_budget NUMERIC(12, 2),
-      currency VARCHAR(10) DEFAULT 'USD',
-      status VARCHAR(20),
-      metadata JSONB,
-      created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
-      created_at TIMESTAMP DEFAULT NOW(),
-      updated_at TIMESTAMP DEFAULT NOW(),
-      UNIQUE(platform, platform_campaign_id)
-    )
-  `;
-  // Budget cap columns for credit reservation
-  await sql`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS total_budget_cents BIGINT DEFAULT 0`;
-  await sql`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS reserved_cents BIGINT DEFAULT 0`;
-  await sql`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS spent_cents BIGINT DEFAULT 0`;
-  await sql`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS closed BOOLEAN DEFAULT false`;
-  // Owner project — per Epic 2 in autoclaw-business-architecture-design.
-  // Nullable + ON DELETE SET NULL so deleting a project doesn't orphan campaigns;
-  // they fall back to "no project" status until reassigned.
-  await sql`ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL`;
-  await sql`CREATE INDEX IF NOT EXISTS idx_campaigns_project_id ON campaigns(project_id) WHERE project_id IS NOT NULL`;
-  await ensureAdCreditsTables(sql);
-}
+// Schema for ad_accounts, campaigns, ad_credits, ad_credit_transactions
+// is declared in lib/schema.sql. Previously created at runtime by
+// ensureAdsTables() / ensureAdCreditsTables(); see docs/google-ads-audit.md D-2.
 
 async function getUserId(sql: ReturnType<typeof getDb>, email: string): Promise<number | null> {
   const rows = await sql`SELECT id FROM users WHERE email = ${email}`;
@@ -100,7 +55,6 @@ export async function GET(req: NextRequest) {
   }
 
   const sql = getDb();
-  await ensureAdsTables();
 
   const userId = await getUserId(sql, session.user.email as string);
   if (!userId) return NextResponse.json({ campaigns: [] });
@@ -162,7 +116,6 @@ export async function POST(req: NextRequest) {
   }
 
   const sql = getDb();
-  await ensureAdsTables();
 
   const userEmail = session.user.email as string;
   const userId = await getUserId(sql, userEmail);

--- a/lib/credits.ts
+++ b/lib/credits.ts
@@ -38,6 +38,13 @@ export interface AdCreditTransaction {
   created_at: string;
 }
 
+/**
+ * @deprecated Schema now lives in `lib/schema.sql`. Function body is
+ * kept (idempotent CREATE IF NOT EXISTS) as a one-release safety net
+ * for any production DB that might predate the schema lift. Remove
+ * after one release confirms no call sites remain.
+ * See docs/google-ads-audit.md D-2.
+ */
 export async function ensureAdCreditsTables(sql: Sql) {
   await sql`
     CREATE TABLE IF NOT EXISTS ad_credits (

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -577,3 +577,74 @@ CREATE TABLE IF NOT EXISTS youtube_uploads (
 CREATE INDEX IF NOT EXISTS idx_youtube_uploads_user ON youtube_uploads(user_id);
 CREATE INDEX IF NOT EXISTS idx_youtube_uploads_status ON youtube_uploads(status);
 CREATE INDEX IF NOT EXISTS idx_youtube_uploads_publish_at ON youtube_uploads(publish_at);
+
+-- ============================================================
+-- Google Ads / Ad Credits
+-- Previously created at runtime by ensureAdsTables() and
+-- ensureAdCreditsTables(). Lifted here so the schema has a single
+-- source of truth. See docs/google-ads-audit.md D-2.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ad_accounts (
+  id SERIAL PRIMARY KEY,
+  org_id INTEGER REFERENCES organizations(id) ON DELETE CASCADE,
+  platform VARCHAR(20) NOT NULL,
+  account_id VARCHAR(100) NOT NULL,
+  account_name VARCHAR(255),
+  credentials JSONB,
+  is_active BOOLEAN DEFAULT true,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(org_id, platform, account_id)
+);
+
+CREATE TABLE IF NOT EXISTS campaigns (
+  id SERIAL PRIMARY KEY,
+  org_id INTEGER REFERENCES organizations(id) ON DELETE CASCADE,
+  ad_account_id INTEGER REFERENCES ad_accounts(id) ON DELETE SET NULL,
+  platform VARCHAR(20) NOT NULL,
+  platform_campaign_id VARCHAR(255),
+  campaign_name VARCHAR(255) NOT NULL,
+  channel VARCHAR(50),
+  daily_budget NUMERIC(12, 2),
+  currency VARCHAR(10) DEFAULT 'USD',
+  status VARCHAR(20),
+  metadata JSONB,
+  -- Budget cap columns for credit reservation
+  total_budget_cents BIGINT DEFAULT 0,
+  reserved_cents BIGINT DEFAULT 0,
+  spent_cents BIGINT DEFAULT 0,
+  closed BOOLEAN DEFAULT false,
+  -- Owner project — per Epic 2 in autoclaw-business-architecture-design.
+  -- Nullable + ON DELETE SET NULL so deleting a project doesn't orphan campaigns;
+  -- they fall back to "no project" status until reassigned.
+  project_id INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(platform, platform_campaign_id)
+);
+CREATE INDEX IF NOT EXISTS idx_campaigns_project_id ON campaigns(project_id) WHERE project_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS ad_credits (
+  org_id INTEGER PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  balance_cents BIGINT NOT NULL DEFAULT 0,
+  reserved_cents BIGINT NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'USD',
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS ad_credit_transactions (
+  id SERIAL PRIMARY KEY,
+  org_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  type VARCHAR(20) NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  balance_after_cents BIGINT NOT NULL,
+  reserved_after_cents BIGINT NOT NULL,
+  reference_type VARCHAR(50),
+  reference_id VARCHAR(255),
+  note TEXT,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_ad_credit_tx_org ON ad_credit_transactions(org_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ad_credit_tx_ref ON ad_credit_transactions(reference_type, reference_id);


### PR DESCRIPTION
## Summary

Wires the existing google-ads-sync and google-ads-reconcile cron
endpoints into the workflow scheduler, and lifts the runtime
CREATE TABLE for Google Ads / Ad Credits schema into `lib/schema.sql`.

Resolves **D-1** (cron not scheduled → spend drift) and **D-2**
(schema not in schema.sql) from `docs/google-ads-audit.md`.

Jira: [KAN-49](https://jytech2023.atlassian.net/browse/KAN-49)

## Changes

- `.github/workflows/cron-maintenance.yml` — add `40 * * * *`
  (google-ads-sync) and `45 3 * * *` (google-ads-reconcile)
- `lib/schema.sql` — append Google Ads / Ad Credits section
- `app/api/google-ads/campaigns/route.ts` — remove `ensureAdsTables()`
- `lib/credits.ts` — mark `ensureAdCreditsTables` `@deprecated`
- `app/api/credits/route.ts`, `app/api/credits/verify/route.ts` —
  remove `ensureAdCreditsTables` call sites

## Verification

- `npm run lint` — no new errors (baseline 88 unchanged)
- `npm run test` — 64 pass / 6 pre-existing fail (unchanged)

## Risk — important

**Not a no-op deploy.** The first cron tick after merge will run real
spend sync on any existing Google Ads campaign for the first time.
Expect audit_logs entries; any campaign over its budget cap will be
auto-paused. This is the intended behavior — D-1 has been silent in
production until now.

## Rollback

If anything misbehaves after merge:
1. Comment out the two new `if:` blocks in `cron-maintenance.yml`
   to halt the schedules.
2. Revert this PR — schema.sql is additive, no DB damage.

Closes KAN-49