### PR TITLE
feat(google-ads): add PERFORMANCE_MAX channel to createCampaign

### DIFF
--- a/app/api/google-ads/campaigns/route.ts
+++ b/app/api/google-ads/campaigns/route.ts
@@ -106,8 +106,8 @@ export async function POST(req: NextRequest) {
   if (totalBudget < dailyBudget) {
     return NextResponse.json({ error: "totalBudget must be >= dailyBudget" }, { status: 400 });
   }
-  if (!["SEARCH", "DISPLAY", "SHOPPING", "VIDEO"].includes(channel)) {
-    return NextResponse.json({ error: "channel must be SEARCH, DISPLAY, SHOPPING, or VIDEO" }, { status: 400 });
+  if (!["SEARCH", "DISPLAY", "SHOPPING", "VIDEO", "PERFORMANCE_MAX"].includes(channel)) {
+    return NextResponse.json({ error: "channel must be SEARCH, DISPLAY, SHOPPING, VIDEO, or PERFORMANCE_MAX" }, { status: 400 });
   }
 
   const customerId = process.env.GOOGLE_ADS_CUSTOMER_ID;
@@ -160,7 +160,7 @@ export async function POST(req: NextRequest) {
     result = await createCampaign({
       name,
       dailyBudget,
-      channel: channel as "SEARCH" | "DISPLAY" | "SHOPPING" | "VIDEO",
+      channel: channel as "SEARCH" | "DISPLAY" | "SHOPPING" | "VIDEO" | "PERFORMANCE_MAX",
       locationIds: Array.isArray(body.locationIds) ? body.locationIds.map(String) : undefined,
     });
   } catch (e) {

--- a/lib/google-ads.ts
+++ b/lib/google-ads.ts
@@ -272,7 +272,7 @@ export const COUNTRIES: Array<{ id: string; code: string; name: string }> = [
 export interface CreateCampaignInput {
   name: string;
   dailyBudget: number;
-  channel?: "SEARCH" | "DISPLAY" | "SHOPPING" | "VIDEO";
+  channel?: "SEARCH" | "DISPLAY" | "SHOPPING" | "VIDEO" | "PERFORMANCE_MAX";
   /** Geo target constant IDs (e.g. ['2840','2124'] for US+CA). Empty = worldwide. */
   locationIds?: string[];
 }
@@ -1115,7 +1115,7 @@ export async function createCampaign(input: CreateCampaignInput): Promise<Create
   const customerId = process.env.GOOGLE_ADS_CUSTOMER_ID;
   if (!customerId) throw new Error("GOOGLE_ADS_CUSTOMER_ID not configured");
 
-  const channel = (input.channel || "SEARCH").toUpperCase() as "SEARCH" | "DISPLAY" | "SHOPPING" | "VIDEO";
+  const channel = (input.channel || "SEARCH").toUpperCase() as "SEARCH" | "DISPLAY" | "SHOPPING" | "VIDEO" | "PERFORMANCE_MAX";
   const out: CreateCampaignResult = { budget: null, campaign: null, errors: [] };
 
   // 1. Budget
@@ -1138,7 +1138,10 @@ export async function createCampaign(input: CreateCampaignInput): Promise<Create
   // Channel-appropriate bidding:
   //   SEARCH/DISPLAY/SHOPPING → manualCpc
   //   VIDEO → maximizeConversions (manualCpc not allowed for VIDEO)
+  //   PERFORMANCE_MAX → maximizeConversions (Smart Bidding required; manualCpc not allowed for PMAX)
   // We also set explicit start/end dates to avoid Google's default end-date bug.
+  // PMAX note: this creates the campaign shell only. Asset groups, audience signals,
+  // and conversion goals are added via separate endpoints (see docs/google-ads-audit.md PR #2c-d).
   const today = new Date();
   const startDate = today.toISOString().slice(0, 10); // YYYY-MM-DD
   const endDateObj = new Date(today.getTime() + 365 * 24 * 60 * 60 * 1000);
@@ -1153,7 +1156,7 @@ export async function createCampaign(input: CreateCampaignInput): Promise<Create
     endDate,
     contains_eu_political_advertising: 2,
   };
-  if (channel === "VIDEO") {
+  if (channel === "VIDEO" || channel === "PERFORMANCE_MAX") {
     campaignCreate.maximizeConversions = {};
   } else {
     campaignCreate.manualCpc = {};


### PR DESCRIPTION
## Summary
Per Slack alignment with Weijing, PMAX is our strategic anchor channel.
The read path in lib/google-ads.ts already recognizes PERFORMANCE_MAX
channelType, but the create path rejected it. This unblocks creating
PMAX campaign shells via the API.

## Changes
- `CreateCampaignInput.channel` union: + PERFORMANCE_MAX
- `createCampaign()`: route PMAX bidding through `maximizeConversions`
  (manualCpc is not allowed for PMAX — same as VIDEO)
- POST `/api/google-ads/campaigns`: + PERFORMANCE_MAX in channel whitelist
- Inline comments: call out that this is the campaign shell only;
  asset groups, audience signals, conversion goals land in PR #2c/#2d

## Safety
- Campaigns are created PAUSED by default — no live spend impact
- No ad-group / keyword scaffolding here, so the "PMAX has no ad groups"
  rule is not violated
- Location targeting via `campaignCriteria` is still valid for PMAX

## Out of scope (follow-up PRs)
- UI dropdown to expose PERFORMANCE_MAX in the create-campaign form
- Asset groups + asset uploads (PR #2c)
- Audience signals (PR #2d)

Refs: KAN-51