### PR TITLE
feat(google-ads): expose PERFORMANCE_MAX in campaign creation UI

### DIFF
--- a/app/[locale]/dashboard/google-ads/page.tsx
+++ b/app/[locale]/dashboard/google-ads/page.tsx
@@ -29,8 +29,11 @@ interface Credits {
   currency: string;
 }
 
-const CHANNELS = ["SEARCH", "DISPLAY", "SHOPPING", "VIDEO", "DEMAND_GEN"] as const;
+const CHANNELS = ["SEARCH", "DISPLAY", "SHOPPING", "VIDEO", "DEMAND_GEN", "PERFORMANCE_MAX"] as const;
 const CHANNELS_DISABLED_FOR_API_CREATE: ReadonlyArray<typeof CHANNELS[number]> = ["VIDEO", "DEMAND_GEN"];
+// PMAX is creatable via API (PR #16 KAN-51), but the shell-only — asset groups,
+// audience signals, and conversion goals are required before it serves. See PR #18.
+const CHANNELS_REQUIRING_FOLLOWUP: ReadonlyArray<typeof CHANNELS[number]> = ["PERFORMANCE_MAX"];
 
 function fromCents(cents: number | string | null | undefined): number {
   return Number(cents || 0) / 100;
@@ -547,6 +550,11 @@ export default function GoogleAdsPage() {
                 {CHANNELS_DISABLED_FOR_API_CREATE.includes(channel) && (
                   <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 px-2 py-1.5 rounded mt-1">
                     ⚠️ {t.videoCreateBlocked || "Video / Demand Gen campaign creation via API is currently disabled. Please create it in Google Ads UI, then use \"Import existing\" to bring it under AutoClaw budget management. See Docs for steps."}
+                  </p>
+                )}
+                {CHANNELS_REQUIRING_FOLLOWUP.includes(channel) && (
+                  <p className="text-xs text-blue-700 bg-blue-50 border border-blue-200 px-2 py-1.5 rounded mt-1">
+                    ℹ️ {t.pmaxShellOnly || "PMAX shell will be created PAUSED. Asset groups, audience signals, and conversion goals are required before it can serve — coming in follow-up PRs."}
                   </p>
                 )}
               </div>

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -1603,6 +1603,7 @@ const en = {
     importExisting: "Import existing",
     videoDisabledLabel: "use Import",
     videoCreateBlocked: "Video and Demand Gen campaign creation via API is disabled (developer-token tier limitation). Create it in Google Ads UI, then use \"Import existing\" to bring it under AutoClaw budget management. See Docs for steps.",
+    pmaxShellOnly: "PMAX shell will be created PAUSED. Asset groups, audience signals, and conversion goals are required before it can serve — coming in follow-up PRs.",
     editLocations: "Edit",
     locationsUpdated: "Locations updated",
     updated: "Updated",

--- a/lib/i18n/ko.ts
+++ b/lib/i18n/ko.ts
@@ -1572,6 +1572,7 @@ const ko = {
     importExisting: "기존 가져오기",
     videoDisabledLabel: "Import 사용",
     videoCreateBlocked: "API Video / Demand Gen 캠페인 생성이 비활성화됨 (개발자 토큰 등급 제한). Google Ads UI에서 만든 후 \"Import existing\"으로 가져오세요. Docs 참조.",
+    pmaxShellOnly: "PMAX 쉘만 생성됩니다(PAUSED). 게재 전에 asset groups, audience signals, conversion goals이 필요하며, 후속 PR에서 제공됩니다.",
     editLocations: "수정",
     locationsUpdated: "지역 업데이트됨",
     updated: "업데이트됨",

--- a/lib/i18n/zh-TW.ts
+++ b/lib/i18n/zh-TW.ts
@@ -1578,6 +1578,7 @@ const zhTW: typeof en = {
     importExisting: "匯入既有",
     videoDisabledLabel: "走 Import",
     videoCreateBlocked: "API 建立 Video / Demand Gen campaign 已停用（developer-token 等級限制）。請先在 Google Ads UI 建立，再用 \"Import existing\" 匯入 AutoClaw 接管預算。詳見 Docs。",
+    pmaxShellOnly: "PMAX 僅建立空 campaign（PAUSED）。投放前需補上 asset groups、audience signals、conversion goals — 將於後續 PR 提供。",
     editLocations: "修改",
     locationsUpdated: "投放地區已更新",
     updated: "已更新",

--- a/lib/i18n/zh.ts
+++ b/lib/i18n/zh.ts
@@ -1582,6 +1582,7 @@ const zh: typeof en = {
     importExisting: "导入已有",
     videoDisabledLabel: "走 Import",
     videoCreateBlocked: "API 创建 Video / Demand Gen campaign 已禁用（developer-token 等级限制）。请先在 Google Ads UI 创建，再用 \"Import existing\" 导入到 AutoClaw 接管预算。详见 Docs。",
+    pmaxShellOnly: "PMAX 仅创建空 campaign（PAUSED）。投放前需补充 asset groups、audience signals、conversion goals — 将在后续 PR 提供。",
     editLocations: "修改",
     locationsUpdated: "投放地区已更新",
     updated: "已更新",


### PR DESCRIPTION
## Summary
Follows up PR #16 (KAN-51). PMAX is now reachable from the API but the
dashboard create-campaign form still hides it. This PR adds PMAX to
the channel dropdown so users can actually create a PMAX campaign
end-to-end from the browser.

## Changes
- `google-ads/page.tsx`: add PERFORMANCE_MAX to the CHANNELS dropdown
- `google-ads/page.tsx`: new `CHANNELS_REQUIRING_FOLLOWUP` set with a
  blue info banner — campaign is created PAUSED but cannot serve until
  asset groups, audience signals, and conversion goals are configured
  (delivered in follow-up PRs per docs/google-ads-audit.md PR #2c-d)
- i18n: add `pmaxShellOnly` key to en, zh, zh-TW, ko

## UX intent
- PMAX is **selectable** (not disabled like VIDEO/DEMAND_GEN — those
  require Import-existing because of developer-token tier limits)
- Selecting PMAX shows a soft blue info note (not amber-warn) because
  the create call will succeed; users just need to understand the
  follow-up step before the campaign can serve

## Acceptance
1. Open the create-campaign form on `/dashboard/google-ads`
2. Channel dropdown now shows `PERFORMANCE_MAX` as the last option
3. Selecting it shows the blue info note
4. Submitting creates a PAUSED PMAX campaign in Google Ads (same path
   as VIDEO — `maximizeConversions` bidding) and a row in the local
   `campaigns` table

## Out of scope (follow-up tickets)
- Asset groups + asset upload UI (KAN-53)
- Audience signals UI (KAN-54)
- Conversion goal attachment (KAN-55)

Refs: KAN-52