### PR TITLE
scaffold(google-ads): KAN-53 schema + types for PMAX asset groups

### DIFF
--- a/lib/google-ads.ts
+++ b/lib/google-ads.ts
@@ -1540,3 +1540,78 @@ export async function createAdGroup(input: CreateAdGroupInput): Promise<{ resour
   const resourceName = (res.data as { results?: Array<{ resourceName?: string }> }).results?.[0]?.resourceName || null;
   return { resourceName };
 }
+
+// ============================================================
+// PMAX Asset Groups (KAN-53) — scaffold
+// ============================================================
+// PMAX campaigns have no ad groups. Instead, asset groups bundle
+// headlines, descriptions, images, logos, and (optional) videos under
+// one PMAX campaign. A PMAX campaign needs at least one asset group
+// meeting Google-Ads-required minimums before it can serve.
+//
+// This is the contract scaffold. Backend API wiring lands in PR #18b;
+// UI lands in PR #18c. See docs/google-ads-audit.md PR #2c and KAN-53.
+
+/** Creative payload for a single PMAX asset group. */
+export interface AssetGroupAssetSpec {
+  /** 3-15 short headlines, ≤30 chars each */
+  headlines: string[];
+  /** 1-5 long headlines, ≤90 chars each */
+  longHeadlines: string[];
+  /** 2-5 descriptions, ≤90 chars each (Google requires ≥1 ≤60 chars too) */
+  descriptions: string[];
+  /** Business name, ≤25 chars, required */
+  businessName: string;
+  /** Landing page URL, required, must start with http(s) */
+  finalUrl: string;
+  /** ≥1 landscape image URL (1.91:1, 1200×628 recommended) */
+  marketingImageUrls: string[];
+  /** ≥1 square image URL (1:1, 1200×1200 recommended) */
+  squareMarketingImageUrls: string[];
+  /** Optional 1:1 logo image URL */
+  logoImageUrl?: string;
+  /** Optional 4:1 landscape logo image URL */
+  landscapeLogoImageUrl?: string;
+  /** Optional YouTube video IDs to attach as video assets */
+  youtubeVideoIds?: string[];
+}
+
+export interface CreateAssetGroupInput {
+  /** Parent PMAX campaign resourceName (e.g. "customers/123/campaigns/456") */
+  campaignResourceName: string;
+  /** Display name shown in Google Ads UI */
+  name: string;
+  /** Creative payload */
+  assets: AssetGroupAssetSpec;
+}
+
+export interface CreateAssetGroupResult {
+  /** Asset group resourceName, e.g. "customers/123/assetGroups/789" */
+  assetGroup: string | null;
+  /** Resource names of every created asset (for follow-up linking / DB persistence) */
+  assetResourceNames: Array<{ field: string; resourceName: string }>;
+  /** Step-by-step errors — asset group can be partially created */
+  errors: Array<{ step: string; details: unknown }>;
+}
+
+/**
+ * Create a Performance Max asset group with required-minimum assets.
+ *
+ * **NOT YET IMPLEMENTED** — scaffold only. Lands in PR #18b (KAN-53).
+ *
+ * When implemented, this will:
+ *   1. Upload all image URLs as Google Ads IMAGE assets via
+ *      `createImageAssetFromUrl()` (reused).
+ *   2. Create text assets (`assets:mutate`) for headlines, long
+ *      headlines, descriptions, business name.
+ *   3. Create the asset group itself (`assetGroups:mutate`).
+ *   4. Link each asset to the asset group via `assetGroupAssets:mutate`
+ *      with the correct `field_type` (HEADLINE, MARKETING_IMAGE, etc.).
+ *
+ * Throws on call so any accidental wiring is caught immediately, not
+ * silently no-op'd.
+ */
+export async function createAssetGroup(input: CreateAssetGroupInput): Promise<CreateAssetGroupResult> {
+  void input;
+  throw new Error("createAssetGroup not implemented yet — lands in PR #18b (KAN-53)");
+}

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -648,3 +648,54 @@ CREATE TABLE IF NOT EXISTS ad_credit_transactions (
 );
 CREATE INDEX IF NOT EXISTS idx_ad_credit_tx_org ON ad_credit_transactions(org_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_ad_credit_tx_ref ON ad_credit_transactions(reference_type, reference_id);
+
+-- ============================================================
+-- PMAX Asset Groups (KAN-53)
+-- ============================================================
+-- Performance Max has no ad groups — instead, asset groups bundle
+-- headlines, long headlines, descriptions, images, logos, and (optional)
+-- videos under one PMAX campaign. A PMAX campaign needs at least one
+-- asset group meeting Google-Ads-required minimums before it becomes
+-- eligible to serve.
+--
+-- See docs/google-ads-audit.md PR #2c. Full backend implementation
+-- lands in PR #18b; this PR (KAN-53 scaffold) defines the data layer
+-- and TypeScript contracts only.
+
+CREATE TABLE IF NOT EXISTS asset_groups (
+  id SERIAL PRIMARY KEY,
+  campaign_id INTEGER NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  platform_asset_group_id VARCHAR(255),    -- Google Ads resourceName tail
+  name VARCHAR(255) NOT NULL,
+  final_url TEXT NOT NULL,
+  status VARCHAR(20) DEFAULT 'PAUSED',     -- ENABLED / PAUSED / REMOVED
+  primary_status VARCHAR(50),              -- OPERATING / LIMITED / NOT_ELIGIBLE / etc.
+  primary_status_reasons JSONB,            -- e.g. ["ASSET_GROUP_DISAPPROVED"]
+  ad_strength VARCHAR(20),                 -- POOR / AVERAGE / GOOD / EXCELLENT
+  created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(campaign_id, platform_asset_group_id)
+);
+CREATE INDEX IF NOT EXISTS idx_asset_groups_campaign ON asset_groups(campaign_id);
+
+CREATE TABLE IF NOT EXISTS assets (
+  id SERIAL PRIMARY KEY,
+  asset_group_id INTEGER NOT NULL REFERENCES asset_groups(id) ON DELETE CASCADE,
+  platform_asset_id VARCHAR(255),          -- Google Ads asset resourceName
+  -- Google Ads PMAX field_type for this asset slot:
+  -- HEADLINE / LONG_HEADLINE / DESCRIPTION / MARKETING_IMAGE /
+  -- SQUARE_MARKETING_IMAGE / LOGO / LANDSCAPE_LOGO / BUSINESS_NAME /
+  -- YOUTUBE_VIDEO / CALL_TO_ACTION_SELECTION
+  field_type VARCHAR(40) NOT NULL,
+  -- Exactly one of text_value / image_url / youtube_video_id is set,
+  -- depending on field_type. Kept flat (vs. polymorphic table) for
+  -- query simplicity at this scale.
+  text_value TEXT,
+  image_url TEXT,
+  youtube_video_id VARCHAR(20),
+  uploaded_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_assets_group ON assets(asset_group_id);
+CREATE INDEX IF NOT EXISTS idx_assets_field_type ON assets(asset_group_id, field_type);


### PR DESCRIPTION
## Summary
First slice of multi-PR KAN-53 (PMAX Asset Groups + Asset Upload).
Data-layer + contract only — zero functional change. Lays foundation
for PR #18b (backend wiring) and PR #18c (UI).

## Changes
- `lib/schema.sql`: add `asset_groups` and `assets` tables + indexes,
  FK to `campaigns(id) ON DELETE CASCADE`. Source-of-truth for the
  PMAX asset-group data model.
- `lib/google-ads.ts`: add TypeScript contracts
  - `AssetGroupAssetSpec` — creative payload shape
  - `CreateAssetGroupInput` / `CreateAssetGroupResult`
  - `createAssetGroup()` stub that throws 'not implemented yet' so
    any accidental call is caught immediately (not silently no-op'd)

## Safety
- 100% additive — no existing code reads/writes the new tables
- Stub throws on call → no silent no-op risk
- schema.sql is source-of-truth (not auto-run); team applies via psql

## Follow-ups in this epic
- PR #18b — backend: `createImageAssetFromUrl` pipeline, `assets:mutate`,
  `assetGroups:mutate`, `assetGroupAssets:mutate`
- PR #18c — UI: asset upload form + API route + DB persistence

Refs: KAN-53