### PR TITLE
feat(google-ads): KAN-53 input validation for PMAX asset groups

### DIFF
--- a/lib/google-ads.test.ts
+++ b/lib/google-ads.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { validateAssetGroupInput, type CreateAssetGroupInput } from "./google-ads";
+
+/**
+ * Validation tests for PMAX asset group input.
+ * Scaffolds the contract enforced before PR #18b's createAssetGroup()
+ * actually calls Google Ads.
+ *
+ * Refs: KAN-53
+ */
+
+function validInput(overrides: Partial<CreateAssetGroupInput["assets"]> = {}): CreateAssetGroupInput {
+  return {
+    campaignResourceName: "customers/1234567890/campaigns/9876543210",
+    name: "Spring Sale 2026",
+    assets: {
+      headlines: ["Buy now", "Save big today", "Free shipping"],
+      longHeadlines: ["Up to 50% off our entire spring collection"],
+      descriptions: [
+        "Limited time offer on top brands.",
+        "Shop our spring collection with free shipping on orders over $50.",
+      ],
+      businessName: "Acme Co",
+      finalUrl: "https://acme.example.com/spring",
+      marketingImageUrls: ["https://cdn.example.com/landscape.jpg"],
+      squareMarketingImageUrls: ["https://cdn.example.com/square.jpg"],
+      ...overrides,
+    },
+  };
+}
+
+describe("validateAssetGroupInput — happy path", () => {
+  it("accepts a minimally valid input", () => {
+    const result = validateAssetGroupInput(validInput());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+describe("validateAssetGroupInput — name + campaign", () => {
+  it("rejects missing name", () => {
+    const result = validateAssetGroupInput({ ...validInput(), name: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("name is required"))).toBe(true);
+  });
+
+  it("rejects bad campaignResourceName", () => {
+    const result = validateAssetGroupInput({ ...validInput(), campaignResourceName: "not-a-resource" });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("campaignResourceName"))).toBe(true);
+  });
+});
+
+describe("validateAssetGroupInput — headlines", () => {
+  it("rejects fewer than 3 headlines", () => {
+    const result = validateAssetGroupInput(validInput({ headlines: ["A", "B"] }));
+    expect(result.errors.some((e) => e.includes("Headlines: at least 3"))).toBe(true);
+  });
+
+  it("rejects more than 15 headlines", () => {
+    const result = validateAssetGroupInput(validInput({ headlines: Array(16).fill("x") }));
+    expect(result.errors.some((e) => e.includes("at most 15"))).toBe(true);
+  });
+
+  it("rejects a headline over 30 chars", () => {
+    const result = validateAssetGroupInput(
+      validInput({ headlines: ["ok", "ok2", "x".repeat(31)] })
+    );
+    expect(result.errors.some((e) => e.includes("1-30 characters"))).toBe(true);
+  });
+});
+
+describe("validateAssetGroupInput — descriptions", () => {
+  it("rejects fewer than 2 descriptions", () => {
+    const result = validateAssetGroupInput(validInput({ descriptions: ["only one"] }));
+    expect(result.errors.some((e) => e.includes("at least 2 required"))).toBe(true);
+  });
+
+  it("rejects when no description ≤60 chars (short slot missing)", () => {
+    const result = validateAssetGroupInput(
+      validInput({
+        descriptions: ["x".repeat(61), "y".repeat(80)],
+      })
+    );
+    expect(result.errors.some((e) => e.includes("short description slot"))).toBe(true);
+  });
+
+  it("rejects a description over 90 chars", () => {
+    const result = validateAssetGroupInput(
+      validInput({ descriptions: ["short ok", "x".repeat(91)] })
+    );
+    expect(result.errors.some((e) => e.includes("1-90 characters"))).toBe(true);
+  });
+});
+
+describe("validateAssetGroupInput — business name + final URL", () => {
+  it("rejects empty business name", () => {
+    const result = validateAssetGroupInput(validInput({ businessName: "" }));
+    expect(result.errors.some((e) => e.includes("Business name is required"))).toBe(true);
+  });
+
+  it("rejects business name > 25 chars", () => {
+    const result = validateAssetGroupInput(validInput({ businessName: "x".repeat(26) }));
+    expect(result.errors.some((e) => e.includes("≤25 characters"))).toBe(true);
+  });
+
+  it("rejects non-http final URL", () => {
+    const result = validateAssetGroupInput(validInput({ finalUrl: "javascript:alert(1)" }));
+    expect(result.errors.some((e) => e.includes("Final URL"))).toBe(true);
+  });
+});
+
+describe("validateAssetGroupInput — images", () => {
+  it("rejects when no landscape marketing image", () => {
+    const result = validateAssetGroupInput(validInput({ marketingImageUrls: [] }));
+    expect(result.errors.some((e) => e.includes("landscape 1.91:1"))).toBe(true);
+  });
+
+  it("rejects when no square marketing image", () => {
+    const result = validateAssetGroupInput(validInput({ squareMarketingImageUrls: [] }));
+    expect(result.errors.some((e) => e.includes("Square marketing images"))).toBe(true);
+  });
+});
+
+describe("validateAssetGroupInput — accumulates multiple errors", () => {
+  it("returns all errors at once, not just the first", () => {
+    const result = validateAssetGroupInput({
+      campaignResourceName: "bad",
+      name: "",
+      assets: {
+        headlines: [],
+        longHeadlines: [],
+        descriptions: [],
+        businessName: "",
+        finalUrl: "",
+        marketingImageUrls: [],
+        squareMarketingImageUrls: [],
+      },
+    });
+    expect(result.valid).toBe(false);
+    // Expect at least 8 distinct errors (one per field family)
+    expect(result.errors.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/lib/google-ads.ts
+++ b/lib/google-ads.ts
@@ -1615,3 +1615,86 @@ export async function createAssetGroup(input: CreateAssetGroupInput): Promise<Cr
   void input;
   throw new Error("createAssetGroup not implemented yet — lands in PR #18b (KAN-53)");
 }
+
+/**
+ * Validate a PMAX asset group input against Google Ads hard minimums
+ * BEFORE calling the API — fails fast so we don't burn API quota or
+ * end up with half-created asset groups.
+ *
+ * Google Ads PMAX asset group requirements (codified here):
+ *   - Headlines:               3-15 items, each ≤30 chars
+ *   - Long headlines:          1-5  items, each ≤90 chars
+ *   - Descriptions:            2-5  items, each ≤90 chars,
+ *                              and ≥1 must be ≤60 chars (short description slot)
+ *   - Business name:           required, ≤25 chars
+ *   - Final URL:               required, must start with http(s)
+ *   - Marketing images:        ≥1 landscape URL
+ *   - Square marketing images: ≥1 square URL
+ *   - Logo / landscape logo:   optional
+ *   - YouTube videos:          optional
+ *
+ * Returns { valid, errors }. `errors` is an empty array on success and
+ * a list of human-readable strings on failure (intended for surfacing
+ * to the UI before submission).
+ */
+export function validateAssetGroupInput(input: CreateAssetGroupInput): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+  const a = input.assets;
+
+  // Name + campaign
+  if (!input.name || !input.name.trim()) errors.push("Asset group name is required.");
+  if (!input.campaignResourceName || !input.campaignResourceName.startsWith("customers/")) {
+    errors.push("campaignResourceName must be a Google Ads resource name like 'customers/123/campaigns/456'.");
+  }
+
+  // Headlines
+  if (!Array.isArray(a.headlines) || a.headlines.length < 3) {
+    errors.push("Headlines: at least 3 required.");
+  } else if (a.headlines.length > 15) {
+    errors.push("Headlines: at most 15 allowed.");
+  } else if (a.headlines.some((h) => !h || h.length > 30)) {
+    errors.push("Headlines: each must be 1-30 characters.");
+  }
+
+  // Long headlines
+  if (!Array.isArray(a.longHeadlines) || a.longHeadlines.length < 1) {
+    errors.push("Long headlines: at least 1 required.");
+  } else if (a.longHeadlines.length > 5) {
+    errors.push("Long headlines: at most 5 allowed.");
+  } else if (a.longHeadlines.some((h) => !h || h.length > 90)) {
+    errors.push("Long headlines: each must be 1-90 characters.");
+  }
+
+  // Descriptions
+  if (!Array.isArray(a.descriptions) || a.descriptions.length < 2) {
+    errors.push("Descriptions: at least 2 required.");
+  } else if (a.descriptions.length > 5) {
+    errors.push("Descriptions: at most 5 allowed.");
+  } else if (a.descriptions.some((d) => !d || d.length > 90)) {
+    errors.push("Descriptions: each must be 1-90 characters.");
+  } else if (!a.descriptions.some((d) => d.length <= 60)) {
+    errors.push("Descriptions: at least one must be ≤60 characters (short description slot).");
+  }
+
+  // Business name
+  if (!a.businessName || !a.businessName.trim()) {
+    errors.push("Business name is required.");
+  } else if (a.businessName.length > 25) {
+    errors.push("Business name: must be ≤25 characters.");
+  }
+
+  // Final URL
+  if (!a.finalUrl || !/^https?:\/\//i.test(a.finalUrl)) {
+    errors.push("Final URL is required and must start with http:// or https://.");
+  }
+
+  // Images
+  if (!Array.isArray(a.marketingImageUrls) || a.marketingImageUrls.length < 1) {
+    errors.push("Marketing images (landscape 1.91:1): at least 1 required.");
+  }
+  if (!Array.isArray(a.squareMarketingImageUrls) || a.squareMarketingImageUrls.length < 1) {
+    errors.push("Square marketing images (1:1): at least 1 required.");
+  }
+
+  return { valid: errors.length === 0, errors };
+}


### PR DESCRIPTION
Adds validateAssetGroupInput() — a pure, fail-fast validator that enforces Google Ads PMAX asset group hard minimums BEFORE we call the API in PR #18b. Stops bad inputs from burning API quota or producing half-created asset groups.

Codified rules (per Google Ads docs)
- Headlines:               3-15, <=30 chars each
- Long headlines:          1-5,  <=90 chars each
- Descriptions:            2-5,  <=90 chars each, >=1 must be <=60 chars
- Business name:           required, <=25 chars
- Final URL:               required, must be http(s)
- Marketing images:        >=1 landscape (1.91:1)
- Square marketing images: >=1 square (1:1)
- campaignResourceName:    must start with 'customers/'

Tests
- 14 Vitest cases in lib/google-ads.test.ts covering happy path, bounds, format violations, and an 'accumulate all errors' case
- First test file under lib/ — follows sibling .test.ts convention

Safety
- Pure function, zero side effects
- No callers yet — PR #18b createAssetGroup() will be first
- Additive; doesn't touch existing code paths

Refs: KAN-53