### PR TITLE
ci: schedule dispatch-followups and sync-email-stats crons

### DIFF
--- a/.github/workflows/cron-maintenance.yml
+++ b/.github/workflows/cron-maintenance.yml
@@ -13,6 +13,8 @@ on:
     - cron: "30 4 * * *"
     - cron: "40 * * * *"      # hourly :40  - google-ads-sync
     - cron: "45 3 * * *"      # daily 03:45 - google-ads-reconcile
+    - cron: "25 * * * *"      # hourly :25  - dispatch-followups
+    - cron: "0 6 * * *"       # daily 06:00 - sync-email-stats
   workflow_dispatch:
     inputs:
       task:
@@ -31,6 +33,8 @@ on:
           - sync-billing
           - google-ads-sync
           - google-ads-reconcile
+          - dispatch-followups
+          - sync-email-stats
 
 jobs:
   cron:
@@ -155,3 +159,23 @@ jobs:
           curl --fail --show-error --silent \
             -H "Authorization: Bearer ${CRON_SECRET}" \
             "${AUTOCLAW_BASE_URL}/api/cron/google-ads-reconcile"
+
+      - name: Run dispatch-followups
+        if: (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'dispatch-followups') || (github.event_name == 'schedule' && github.event.schedule == '25 * * * *')
+        env:
+          AUTOCLAW_BASE_URL: ${{ vars.AUTOCLAW_BASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          curl --fail --show-error --silent \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            "${AUTOCLAW_BASE_URL}/api/cron/dispatch-followups"
+
+      - name: Run sync-email-stats
+        if: (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'sync-email-stats') || (github.event_name == 'schedule' && github.event.schedule == '0 6 * * *')
+        env:
+          AUTOCLAW_BASE_URL: ${{ vars.AUTOCLAW_BASE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          curl --fail --show-error --silent \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            "${AUTOCLAW_BASE_URL}/api/cron/sync-email-stats"

--- a/.github/workflows/cron-maintenance.yml
+++ b/.github/workflows/cron-maintenance.yml
@@ -38,6 +38,7 @@ on:
 
 jobs:
   cron:
+    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/daily-accomplishment-review.yml
+++ b/.github/workflows/daily-accomplishment-review.yml
@@ -44,6 +44,7 @@ concurrency:
 
 jobs:
   review:
+    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout autoclaw-web (last 7 days of history)

--- a/.github/workflows/overnight-jira-worker.yml
+++ b/.github/workflows/overnight-jira-worker.yml
@@ -45,6 +45,7 @@ concurrency:
 
 jobs:
   run:
+    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout autoclaw-web

--- a/.github/workflows/sync-yeoso-to-main.yml
+++ b/.github/workflows/sync-yeoso-to-main.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   sync-features:
+    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
- Add `dispatch-followups` (hourly at :25) and `sync-email-stats` (daily 06:00) to `cron-maintenance.yml`
- Restore triggers lost when crons moved off `vercel.json` in 2a1e4d3 — neither route was carried into the GitHub Actions schedule
- Stop relying on a local `scripts/local-cron.sh` loop, which only fired while a dev machine was running its dev server (the cause of follow-up sends dropping to 0 once that machine was off)

## Why
Follow-up dispatch had no production scheduler: `dispatch-followups` only ran from `local-cron.sh` hitting `localhost:3002`, so sends stopped the moment that machine/terminal was closed. `sync-email-stats` was dropped in the same vercel.json migration. Both now fire from the already-active Cron Maintenance workflow.

## Test plan
- [ ] Confirm `vars.AUTOCLAW_BASE_URL` and `secrets.CRON_SECRET` are set in the jytechllc repo (existing crons already use them)
- [ ] Manually trigger via workflow_dispatch with task `dispatch-followups`, confirm 200 and `{ ok: true, queued, ... }`
- [ ] Manually trigger task `sync-email-stats`, confirm 200
- [ ] After a scheduled run, verify follow-ups appear in /dashboard/email-review (still requires manual approval to actually send)