### PR TITLE
Revert: schedule dispatch-followups and sync-email-stats crons (#25)

### DIFF
--- a/.github/workflows/cron-maintenance.yml
+++ b/.github/workflows/cron-maintenance.yml
@@ -13,8 +13,6 @@ on:
     - cron: "30 4 * * *"
     - cron: "40 * * * *"      # hourly :40  - google-ads-sync
     - cron: "45 3 * * *"      # daily 03:45 - google-ads-reconcile
-    - cron: "25 * * * *"      # hourly :25  - dispatch-followups
-    - cron: "0 6 * * *"       # daily 06:00 - sync-email-stats
   workflow_dispatch:
     inputs:
       task:
@@ -33,12 +31,9 @@ on:
           - sync-billing
           - google-ads-sync
           - google-ads-reconcile
-          - dispatch-followups
-          - sync-email-stats
 
 jobs:
   cron:
-    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -160,23 +155,3 @@ jobs:
           curl --fail --show-error --silent \
             -H "Authorization: Bearer ${CRON_SECRET}" \
             "${AUTOCLAW_BASE_URL}/api/cron/google-ads-reconcile"
-
-      - name: Run dispatch-followups
-        if: (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'dispatch-followups') || (github.event_name == 'schedule' && github.event.schedule == '25 * * * *')
-        env:
-          AUTOCLAW_BASE_URL: ${{ vars.AUTOCLAW_BASE_URL }}
-          CRON_SECRET: ${{ secrets.CRON_SECRET }}
-        run: |
-          curl --fail --show-error --silent \
-            -H "Authorization: Bearer ${CRON_SECRET}" \
-            "${AUTOCLAW_BASE_URL}/api/cron/dispatch-followups"
-
-      - name: Run sync-email-stats
-        if: (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'sync-email-stats') || (github.event_name == 'schedule' && github.event.schedule == '0 6 * * *')
-        env:
-          AUTOCLAW_BASE_URL: ${{ vars.AUTOCLAW_BASE_URL }}
-          CRON_SECRET: ${{ secrets.CRON_SECRET }}
-        run: |
-          curl --fail --show-error --silent \
-            -H "Authorization: Bearer ${CRON_SECRET}" \
-            "${AUTOCLAW_BASE_URL}/api/cron/sync-email-stats"

--- a/.github/workflows/daily-accomplishment-review.yml
+++ b/.github/workflows/daily-accomplishment-review.yml
@@ -44,7 +44,6 @@ concurrency:
 
 jobs:
   review:
-    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout autoclaw-web (last 7 days of history)

--- a/.github/workflows/overnight-jira-worker.yml
+++ b/.github/workflows/overnight-jira-worker.yml
@@ -45,7 +45,6 @@ concurrency:
 
 jobs:
   run:
-    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout autoclaw-web

--- a/.github/workflows/sync-yeoso-to-main.yml
+++ b/.github/workflows/sync-yeoso-to-main.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   sync-features:
-    if: github.repository == 'jytechllc/autoclaw-web'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
- Revert #25 in full — those CI changes were committed to autoclaw-web by mistake
- Restores `cron-maintenance.yml`, `daily-accomplishment-review.yml`, `overnight-jira-worker.yml`, `sync-yeoso-to-main.yml` to their pre-#25 state
- The follow-up dispatch / cron work was intended for the usproglove project, not this repo