### PR TITLE
feat(google-ads): KAN-53 'Use demo content' button for PMAX asset gro…

### DIFF
--- a/app/[locale]/dashboard/google-ads/[id]/page.tsx
+++ b/app/[locale]/dashboard/google-ads/[id]/page.tsx
@@ -10,6 +10,41 @@ import { useOrg } from "@/components/OrgContext";
 import { COUNTRIES } from "@/lib/google-ads";
 import { applyPlatformMarkup, paymentGatewayFee, platformFee, isPaidPlan } from "@/lib/billing";
 
+/**
+ * Realistic-looking placeholder content for the PMAX asset group form.
+ * One-click prefill — meets every Google Ads required minimum so the
+ * form is submittable as-is. Useful for first-time UX and for recording
+ * smooth Loom / Vercel-preview demos without typing 9 fields live.
+ *
+ * Images are stable Unsplash photos sized for PMAX aspect ratios. Final
+ * URL points to our public homepage so the click-through is real.
+ */
+const DEMO_ASSET_GROUP_CONTENT = {
+  name: "Demo Asset Group",
+  businessName: "AutoClaw Demo",
+  finalUrl: "https://autoclaw.com",
+  headlines: [
+    "Try AutoClaw Free",
+    "AI Outbound Sales",
+    "Boost Your Pipeline",
+    "Book More Meetings",
+  ].join("\n"),
+  longHeadlines: [
+    "Automate B2B outbound with AI agents that book meetings while you sleep",
+  ].join("\n"),
+  descriptions: [
+    "Find leads, write personalized emails, book meetings. All on autopilot.",
+    "AutoClaw replaces your SDR stack with one AI platform you control.",
+  ].join("\n"),
+  marketingImageUrls: [
+    "https://images.unsplash.com/photo-1551434678-e076c223a692?w=1200&h=628&fit=crop",
+  ].join("\n"),
+  squareImageUrls: [
+    "https://images.unsplash.com/photo-1551434678-e076c223a692?w=1200&h=1200&fit=crop",
+  ].join("\n"),
+  logoUrl: "",
+} as const;
+
 interface CampaignRow {
   id: number;
   platform_campaign_id: string;
@@ -471,6 +506,19 @@ export default function CampaignDetailPage() {
       setAgError(e instanceof Error ? e.message : "Failed");
     }
     setAgSubmitting(false);
+  }
+
+  function handleFillDemoAssetGroup() {
+    setAssetName(DEMO_ASSET_GROUP_CONTENT.name);
+    setAssetBusinessName(DEMO_ASSET_GROUP_CONTENT.businessName);
+    setAssetFinalUrl(DEMO_ASSET_GROUP_CONTENT.finalUrl);
+    setAssetHeadlines(DEMO_ASSET_GROUP_CONTENT.headlines);
+    setAssetLongHeadlines(DEMO_ASSET_GROUP_CONTENT.longHeadlines);
+    setAssetDescriptions(DEMO_ASSET_GROUP_CONTENT.descriptions);
+    setAssetMarketingImageUrls(DEMO_ASSET_GROUP_CONTENT.marketingImageUrls);
+    setAssetSquareImageUrls(DEMO_ASSET_GROUP_CONTENT.squareImageUrls);
+    setAssetLogoUrl(DEMO_ASSET_GROUP_CONTENT.logoUrl);
+    setAssetError("");
   }
 
   async function handleCreateAssetGroup() {
@@ -1361,9 +1409,19 @@ export default function CampaignDetailPage() {
 
             {showAssetForm && (
               <div className="border border-gray-200 rounded-lg p-3 mb-3 space-y-3 bg-gray-50">
-                <p className="text-xs text-blue-700 bg-blue-50 border border-blue-200 px-2 py-1.5 rounded">
-                  ℹ️ {t.assetGroupFormHint || "Asset group will be created PAUSED. Required: ≥3 headlines, ≥1 long headline, ≥2 descriptions, business name, final URL, ≥1 landscape image, ≥1 square image."}
-                </p>
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-xs text-blue-700 bg-blue-50 border border-blue-200 px-2 py-1.5 rounded flex-1">
+                    ℹ️ {t.assetGroupFormHint || "Asset group will be created PAUSED. Required: ≥3 headlines, ≥1 long headline, ≥2 descriptions, business name, final URL, ≥1 landscape image, ≥1 square image."}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={handleFillDemoAssetGroup}
+                    className="shrink-0 text-xs px-2.5 py-1.5 border border-gray-300 rounded-lg hover:bg-white cursor-pointer"
+                    title={t.useDemoContentHint || "Fill the form with a working PMAX example so you can review or demo without typing"}
+                  >
+                    ✨ {t.useDemoContent || "Use demo content"}
+                  </button>
+                </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   <input
                     value={assetName}

--- a/lib/i18n/en.ts
+++ b/lib/i18n/en.ts
@@ -1569,6 +1569,8 @@ const en = {
     marketingImagesPlaceholder: "Landscape image URLs (1.91:1, ≥1, one per line, public PNG/JPEG)",
     squareImagesPlaceholder: "Square image URLs (1:1, ≥1, one per line, public PNG/JPEG)",
     logoUrlPlaceholder: "Logo URL (1:1, optional)",
+    useDemoContent: "Use demo content",
+    useDemoContentHint: "Fill the form with a working PMAX example so you can review or demo without typing",
     dailyTrend: "Daily trend",
     chartNoTrafficYet: "No traffic yet — Google may still be reviewing the campaign",
     chartZeroForMetric: "No data for this metric in the last 30 days",

--- a/lib/i18n/ko.ts
+++ b/lib/i18n/ko.ts
@@ -1538,6 +1538,8 @@ const ko = {
     marketingImagesPlaceholder: "가로 이미지 URL (1.91:1, ≥1, 한 줄에 하나, 공개 PNG/JPEG)",
     squareImagesPlaceholder: "정사각형 이미지 URL (1:1, ≥1, 한 줄에 하나, 공개 PNG/JPEG)",
     logoUrlPlaceholder: "Logo URL (1:1, 선택사항)",
+    useDemoContent: "데모 콘텐츠 사용",
+    useDemoContentHint: "PMAX 작동 예시를 한 번에 채워 넣어 검토 또는 데모를 입력 없이 진행할 수 있습니다",
     dailyTrend: "일별 추이",
     chartNoTrafficYet: "아직 트래픽 없음 — Google이 검토 중일 수 있습니다",
     chartZeroForMetric: "지난 30일 동안 이 지표 데이터 없음",

--- a/lib/i18n/zh-TW.ts
+++ b/lib/i18n/zh-TW.ts
@@ -1544,6 +1544,8 @@ const zhTW: typeof en = {
     marketingImagesPlaceholder: "橫版圖 URL（1.91:1，≥1 張，每行一條，公開 PNG/JPEG）",
     squareImagesPlaceholder: "方圖 URL（1:1，≥1 張，每行一條，公開 PNG/JPEG）",
     logoUrlPlaceholder: "Logo URL（1:1，選填）",
+    useDemoContent: "使用範例內容",
+    useDemoContentHint: "一鍵填入一份可提交的 PMAX 範例，便於演示或預覽，無需手動輸入",
     dailyTrend: "每日趨勢",
     chartNoTrafficYet: "尚未有流量 — Google 可能還在審核",
     chartZeroForMetric: "過去 30 天該指標無資料",

--- a/lib/i18n/zh.ts
+++ b/lib/i18n/zh.ts
@@ -1548,6 +1548,8 @@ const zh: typeof en = {
     marketingImagesPlaceholder: "横版图 URL（1.91:1，≥1 张，每行一条，公开 PNG/JPEG）",
     squareImagesPlaceholder: "方图 URL（1:1，≥1 张，每行一条，公开 PNG/JPEG）",
     logoUrlPlaceholder: "Logo URL（1:1，可选）",
+    useDemoContent: "使用示例内容",
+    useDemoContentHint: "一键填入一份可提交的 PMAX 示例，便于演示或预览，无需手动输入",
     dailyTrend: "每日趋势",
     chartNoTrafficYet: "还没有流量 — Google 可能还在审核",
     chartZeroForMetric: "过去 30 天该指标无数据",


### PR DESCRIPTION
…up form

Polish on top of KAN-53c. One-click prefill of the PMAX asset group form with realistic, submittable content. Materially reduces friction for first-time users and makes Loom / Vercel-preview demos far smoother (no need to type 9 fields live).

Changes
- page.tsx: add DEMO_ASSET_GROUP_CONTENT constant — meets every Google Ads required minimum (name, business name, final URL, 4 headlines, 1 long headline, 2 descriptions, 1 landscape image, 1 square image). Uses public Unsplash images sized for PMAX aspect ratios; final URL points to autoclaw.com.
- page.tsx: add handleFillDemoAssetGroup() — populates every form field in one click and clears any prior error.
- page.tsx: add '✨ Use demo content' button next to the info banner inside the form. Right-aligned, tertiary style (neutral border, not competing with the primary 'Create' button).
- i18n: useDemoContent + useDemoContentHint across en / zh / zh-TW / ko.

Safety
- Pure UI prefill — does not bypass server-side validator.
- Submitted demo content goes through the same auth + rate-limit + validator path as any user input.
- No new API calls, no new dependencies.

Refs: KAN-53